### PR TITLE
Configurable ar

### DIFF
--- a/Perl/shared/zstd/Makefile.PL
+++ b/Perl/shared/zstd/Makefile.PL
@@ -66,7 +66,7 @@ CFLAGS  += -fPIC -Wall -Wextra -Wcast-qual -Wcast-align -Wshadow -Wstrict-aliasi
            -Wswitch-enum -Wdeclaration-after-statement -Wstrict-prototypes -Wundef \
            -Wpointer-arith
 CFLAGS  += $(MOREFLAGS)
-AR       = ar
+AR      ?= ar
 ARFLAGS  = rcs
 RM       = rm -f
 


### PR DESCRIPTION
When cross compiling, the ar executable name is prefixed with the target system name. This change allows build systems to override the AR executable name.

This fixes cross compilation in nixpkgs. I have no knowledge of any other side-effects this change might bring.